### PR TITLE
Add .editorconfig file.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+# http://editorconfig.org
+root = true
+
+[*]
+indent_style = tab
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true


### PR DESCRIPTION
The .editorconfig, for editors that support it, enforces code conventions like spaces vs tabs and other related options. Thought it would be helpful for future contributors.
