### PR TITLE
Allow overriding of config with environment variables.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ ehthumbs.db
 Thumbs.db
 
 node_modules
+
+# Local settings #
+##################
+.env

--- a/config.js
+++ b/config.js
@@ -1,11 +1,11 @@
+require('dotenv').load()
 
 var config = {};
 
-config.webPort = 8000;
-config.serialBaudRate = 115200;
-config.webcamPort = 8080;  // expects a webcam stream from mjpg_streamer
-config.xmax = 600 // Max length of X Axis in mm
-config.ymax = 400 // Max length of Y Axis in mm
-
+config.webPort = process.env.WEB_PORT || 8000;
+config.serialBaudRate = process.env.SERIAL_BAUD_RATE || 115200;
+config.webcamPort = process.env.WEBCAM_PORT || 8080;  // expects a webcam stream from mjpg_streamer
+config.xmax = process.env.X_MAX || 600 // Max length of X Axis in mm
+config.ymax = process.env.Y_MAX || 400 // Max length of Y Axis in mm
 
 module.exports = config;

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
-  "name" : "reprapweb",
-  "description" : "a fully featured web ui for reprap and other 3d printers",
-  "dependencies" :
-  { "node-static" : "0.7.x"
-  , "serialport" : "2.0.x"
-  , "socket.io" : "1.3.x"
+  "name": "reprapweb",
+  "description": "a fully featured web ui for reprap and other 3d printers",
+  "dependencies": {
+    "dotenv": "1.2.0",
+    "node-static": "0.7.x",
+    "serialport": "2.0.x",
+    "socket.io": "1.3.x"
   }
 }


### PR DESCRIPTION
In order to let end users customize their environment, Ive added the ability to override the basic settings via environment variables in `config.js` by adding `.env` file to the directory that overrides settings using dotenv.
