### PR TITLE
Make dotenv silent.

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,4 +1,4 @@
-require('dotenv').load()
+require('dotenv').load({ silent: true });
 
 var config = {};
 


### PR DESCRIPTION
Dont warn the user if a .env file is not present.
