### PR TITLE
Optimize the laser cutting path around the edges of images by not having move commands when not burning

### DIFF
--- a/i/raster/index.html
+++ b/i/raster/index.html
@@ -314,9 +314,13 @@ function PostGcode() {
 									if (firmware.indexOf('Grbl') == 0) {
 											s += 'M3\n'
 									}
-
-									s += 'G1 X'+posx+' Y'+gcodey+' S'+lastIntensity+'\n';
-
+									if (lastIntensity == 0) {
+										// If we are not burning, there is no need to move the laser
+										s += 'G1 S'+lastIntensity+'\n'
+									} else {
+										s += 'G1 X'+posx+' Y'+gcodey+' S'+lastIntensity+'\n';
+									}
+									
 									if (firmware.indexOf('Grbl') == 0) {
 											s += 'M5\n'
 									}


### PR DESCRIPTION
I am unsure of if I coded this right, but this should avoid move instructions around the edges of the images where you are not actually burning any.
